### PR TITLE
feat(chart): add ticker symbol watermark to full chart

### DIFF
--- a/web/src/components/charts/TradingChart.tsx
+++ b/web/src/components/charts/TradingChart.tsx
@@ -500,7 +500,7 @@ export function TradingChart({ className, onCrosshairPriceChange, crosshairPrice
         <span
           className="font-extrabold"
           style={{
-            fontSize: 'clamp(6rem, 22vw, 18rem)',
+            fontSize: 'clamp(1.8rem, 6.6vw, 5.4rem)',
             color: 'rgba(255, 255, 255, 0.12)',
             fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
             letterSpacing: '0.25em',


### PR DESCRIPTION
## Summary
- Add TradingView-style watermark displaying the active ticker symbol (e.g., GME) as large, faded background text on the chart
- Watermark is visible but subtle at 12% opacity, using click-through with `pointer-events: none`
- Responsive sizing using `clamp(6rem, 22vw, 18rem)` for different screen sizes

## Screenshot
The GME ticker symbol appears as a large, semi-transparent watermark behind the chart data - similar to how TradingView displays the symbol.

## Test plan
- [ ] Navigate to /app and click "Full Chart"
- [ ] Verify the active symbol (GME by default) appears as a faded watermark behind the chart
- [ ] Change symbols and verify the watermark updates
- [ ] Ensure chart interactions (zoom, pan, crosshair) still work through the watermark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a center-aligned watermark overlay to trading charts displaying the active symbol. The overlay features a large, responsive font with a translucent appearance and does not interfere with chart interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->