### PR TITLE
fix(stripe): fix webhook env vars and add subscription columns migration

### DIFF
--- a/core/api_server.py
+++ b/core/api_server.py
@@ -910,8 +910,8 @@ class DeepStackAPIServer:
         try:
             from supabase import create_client
 
-            supabase_url = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-            supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            supabase_url = os.getenv("SUPABASE_URL")
+            supabase_key = os.getenv("SUPABASE_SERVICE_KEY")
 
             if not supabase_url or not supabase_key:
                 logger.error("Supabase credentials not configured")
@@ -952,8 +952,8 @@ class DeepStackAPIServer:
         try:
             from supabase import create_client
 
-            supabase_url = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-            supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            supabase_url = os.getenv("SUPABASE_URL")
+            supabase_key = os.getenv("SUPABASE_SERVICE_KEY")
 
             if not supabase_url or not supabase_key:
                 return
@@ -980,8 +980,8 @@ class DeepStackAPIServer:
         try:
             from supabase import create_client
 
-            supabase_url = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-            supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            supabase_url = os.getenv("SUPABASE_URL")
+            supabase_key = os.getenv("SUPABASE_SERVICE_KEY")
 
             if not supabase_url or not supabase_key:
                 return
@@ -1014,8 +1014,8 @@ class DeepStackAPIServer:
         try:
             from supabase import create_client
 
-            supabase_url = os.getenv("NEXT_PUBLIC_SUPABASE_URL")
-            supabase_key = os.getenv("SUPABASE_SERVICE_ROLE_KEY")
+            supabase_url = os.getenv("SUPABASE_URL")
+            supabase_key = os.getenv("SUPABASE_SERVICE_KEY")
 
             if not supabase_url or not supabase_key:
                 return

--- a/web/supabase/migrations/20251211_add_subscription_columns.sql
+++ b/web/supabase/migrations/20251211_add_subscription_columns.sql
@@ -1,0 +1,21 @@
+-- Add subscription-related columns to profiles table
+-- Required for Stripe payment integration
+
+ALTER TABLE profiles
+ADD COLUMN IF NOT EXISTS subscription_tier TEXT DEFAULT 'free' CHECK (subscription_tier IN ('free', 'pro', 'elite')),
+ADD COLUMN IF NOT EXISTS stripe_customer_id TEXT,
+ADD COLUMN IF NOT EXISTS stripe_subscription_id TEXT,
+ADD COLUMN IF NOT EXISTS subscription_status TEXT DEFAULT 'inactive' CHECK (subscription_status IN ('inactive', 'active', 'past_due', 'canceled')),
+ADD COLUMN IF NOT EXISTS subscription_starts_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS subscription_ends_at TIMESTAMPTZ;
+
+-- Add index for faster lookups by stripe_customer_id
+CREATE INDEX IF NOT EXISTS idx_profiles_stripe_customer_id ON profiles(stripe_customer_id);
+
+-- Comment on columns for documentation
+COMMENT ON COLUMN profiles.subscription_tier IS 'User subscription tier: free, pro, or elite';
+COMMENT ON COLUMN profiles.stripe_customer_id IS 'Stripe customer ID for subscription management';
+COMMENT ON COLUMN profiles.stripe_subscription_id IS 'Stripe subscription ID';
+COMMENT ON COLUMN profiles.subscription_status IS 'Current subscription status: inactive, active, past_due, canceled';
+COMMENT ON COLUMN profiles.subscription_starts_at IS 'When the current subscription started';
+COMMENT ON COLUMN profiles.subscription_ends_at IS 'When the subscription ends or was canceled';


### PR DESCRIPTION
## Summary
- Fix environment variable names in webhook handlers to match production `.env`
- Add migration for subscription columns in profiles table

## Root Cause
The upgrade flow to Stripe checkout worked, but after payment the webhook couldn't update the profile because:
1. **Missing database columns** - profiles table didn't have subscription_tier, stripe_customer_id, etc.
2. **Wrong env var names** - code used `NEXT_PUBLIC_SUPABASE_URL` but .env has `SUPABASE_URL`

## Changes
- `core/api_server.py`: Fixed 4 occurrences of env var names
- Added migration SQL (already applied to production DB)

## Test plan
- [x] Migration applied to Supabase production
- [ ] Deploy backend to Railway
- [ ] Test upgrade flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend infrastructure to support subscription management with multiple tiers (free, pro, elite).
  * Configured database schema to track subscription status and billing integration capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->