### PR TITLE
fix(profile): add onClick handler to Upgrade button

### DIFF
--- a/web/src/components/layout/ProfilePanel.tsx
+++ b/web/src/components/layout/ProfilePanel.tsx
@@ -274,7 +274,15 @@ export function ProfilePanel() {
                                             </p>
                                         </div>
                                         {tier === 'free' && (
-                                            <Button size="sm" variant="default" className="text-xs">
+                                            <Button
+                                                size="sm"
+                                                variant="default"
+                                                className="text-xs"
+                                                onClick={() => {
+                                                    toggleProfile(); // Close panel
+                                                    window.location.href = '/pricing';
+                                                }}
+                                            >
                                                 Upgrade
                                             </Button>
                                         )}


### PR DESCRIPTION
## Summary
The Upgrade button in the profile panel was non-functional - missing onClick handler.

## Fix
Now clicks:
1. Close the profile panel
2. Navigate to `/pricing`

## Test
Click the Upgrade button in the profile panel (slides out from left) - should take you to pricing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)