### PR TITLE
feat(firewall): redesign mobile indicators with subtle dot + glow

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -686,6 +686,46 @@ body:has(.landing-page) > div > div > div {
     0 0 12px oklch(0.60 0.20 25 / 20%);
 }
 
+/* ===========================================
+   EMOTIONAL FIREWALL - Subtle Status Glows
+   =========================================== */
+
+/* Safe state - subtle green ambient glow */
+.firewall-glow-safe {
+  box-shadow:
+    inset 0 0 20px oklch(0.55 0.15 145 / 8%),
+    0 0 15px oklch(0.55 0.15 145 / 6%);
+}
+
+/* Warning state - warm amber glow (matches existing ds-glow) */
+.firewall-glow-warning {
+  box-shadow:
+    inset 0 0 25px oklch(0.65 0.18 85 / 12%),
+    0 0 20px oklch(0.65 0.18 85 / 10%);
+}
+
+/* Blocked state - red alert glow */
+.firewall-glow-blocked {
+  box-shadow:
+    inset 0 0 30px oklch(0.55 0.20 25 / 15%),
+    0 0 25px oklch(0.55 0.20 25 / 12%);
+}
+
+/* Animated pulse for warning/blocked states */
+@keyframes firewall-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.7;
+  }
+}
+
+.firewall-glow-warning,
+.firewall-glow-blocked {
+  animation: firewall-pulse 3s ease-in-out infinite;
+}
+
 /* Dissolving Edge Gradients */
 .led-fade-left {
   background: linear-gradient(90deg,

--- a/web/src/components/chat/ChatInput.tsx
+++ b/web/src/components/chat/ChatInput.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'next/navigation';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { CommandPalette } from './CommandPalette';
 import { cn } from '@/lib/utils';
+import { FirewallStatusDot, useFirewallGlow } from '@/components/emotional-firewall';
 
 type ChatInputProps = {
   onSend: (message: string) => void;
@@ -28,6 +29,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
   const { user, loading } = useAuth();
   const router = useRouter();
   const { isMobile } = useIsMobile();
+  const { glowClass } = useFirewallGlow();
 
   const handleCommand = useCallback(async (command: string) => {
     // Populate input for visual feedback
@@ -145,7 +147,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
           </Button>
         )}
 
-        <div className="flex-1 relative">
+        <div className={cn("flex-1 relative rounded-xl transition-shadow duration-500", glowClass)}>
           <Textarea
             ref={textareaRef}
             value={input}
@@ -156,7 +158,7 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
             inputMode="text"
             enterKeyHint="send"
             className={cn(
-              "resize-none rounded-xl bg-primary/8 border border-primary/20 pr-8 focus-visible:ring-0 focus-visible:ring-offset-0 text-foreground placeholder:text-muted-foreground/50 caret-primary shadow-[inset_0_0_12px_rgba(178,120,50,0.15),0_0_8px_rgba(178,120,50,0.1)] scrollbar-hide whitespace-pre-wrap break-all",
+              "resize-none rounded-xl bg-primary/8 border border-primary/20 pr-8 focus-visible:ring-0 focus-visible:ring-offset-0 text-foreground placeholder:text-muted-foreground/50 caret-primary scrollbar-hide whitespace-pre-wrap break-all",
               isMobile
                 ? "min-h-[40px] max-h-[120px] px-3 py-2 text-base"
                 : "min-h-[44px] max-h-[200px] px-4 py-3"
@@ -171,6 +173,11 @@ export function ChatInput({ onSend, disabled }: ChatInputProps) {
             />
           )}
         </div>
+
+        {/* Firewall Status Dot - subtle indicator */}
+        {isMobile && (
+          <FirewallStatusDot size="sm" className="shrink-0" />
+        )}
 
         <Button
           onClick={handleSubmit}

--- a/web/src/components/chat/ConversationView.tsx
+++ b/web/src/components/chat/ConversationView.tsx
@@ -487,10 +487,12 @@ export function ConversationView() {
                         <PresetGrid onSelect={handlePresetClick} />
                     </div>
 
-                    {/* Emotional Firewall Banner */}
-                    <div className="w-full">
-                        <EmotionalFirewallBanner compact />
-                    </div>
+                    {/* Emotional Firewall Banner - Desktop only (mobile uses dot indicator in ChatInput) */}
+                    {!isMobile && (
+                        <div className="w-full">
+                            <EmotionalFirewallBanner compact />
+                        </div>
+                    )}
 
                     {/* Chat Limit Indicator */}
                     {showChatLimitIndicator && (
@@ -677,7 +679,8 @@ export function ConversationView() {
                     {/* Chat Input */}
                     <div className="flex-shrink-0 p-3 bg-background/90 backdrop-blur-md border-t border-border/30">
                         <div className="max-w-3xl mx-auto w-full space-y-2">
-                            <EmotionalFirewallBanner compact className="mb-2" />
+                            {/* Desktop only - mobile uses dot indicator in ChatInput */}
+                            {!isMobile && <EmotionalFirewallBanner compact className="mb-2" />}
                             {showChatLimitIndicator && (
                                 <ChatLimitBanner used={chatsToday} limit={dailyLimit} className="mb-2" />
                             )}

--- a/web/src/components/emotional-firewall/FirewallStatusDot.tsx
+++ b/web/src/components/emotional-firewall/FirewallStatusDot.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useEmotionalFirewall } from '@/hooks/useEmotionalFirewall';
+import { cn } from '@/lib/utils';
+import { useState } from 'react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+interface FirewallStatusDotProps {
+  className?: string;
+  size?: 'sm' | 'md';
+  showLabel?: boolean;
+}
+
+/**
+ * Subtle LED-style dot indicator for emotional firewall status.
+ * Designed to be "hidden in plain sight" - minimal but informative.
+ */
+export function FirewallStatusDot({
+  className,
+  size = 'sm',
+  showLabel = false,
+}: FirewallStatusDotProps) {
+  const { isBlocked, isWarning, isSafe, loading, patterns } = useEmotionalFirewall();
+  const [isHovered, setIsHovered] = useState(false);
+
+  if (loading) return null;
+
+  // Status colors and labels
+  const getStatusConfig = () => {
+    if (isBlocked) {
+      return {
+        dotColor: 'bg-red-500',
+        glowColor: 'shadow-[0_0_8px_rgba(239,68,68,0.6),0_0_16px_rgba(239,68,68,0.3)]',
+        pulseColor: 'bg-red-400',
+        label: 'Blocked',
+        description: 'Trading blocked - emotional pattern detected',
+      };
+    }
+    if (isWarning) {
+      return {
+        dotColor: 'bg-yellow-500',
+        glowColor: 'shadow-[0_0_8px_rgba(234,179,8,0.6),0_0_16px_rgba(234,179,8,0.3)]',
+        pulseColor: 'bg-yellow-400',
+        label: 'Caution',
+        description: 'Caution advised - approaching limits',
+      };
+    }
+    return {
+      dotColor: 'bg-green-500',
+      glowColor: 'shadow-[0_0_6px_rgba(34,197,94,0.5),0_0_12px_rgba(34,197,94,0.25)]',
+      pulseColor: 'bg-green-400',
+      label: 'Protected',
+      description: 'Clear to trade',
+    };
+  };
+
+  const config = getStatusConfig();
+  const sizeClasses = size === 'sm' ? 'h-2 w-2' : 'h-2.5 w-2.5';
+  const pulseSizeClasses = size === 'sm' ? 'h-2 w-2' : 'h-2.5 w-2.5';
+
+  const DotElement = (
+    <div
+      className={cn('flex items-center gap-1.5 cursor-pointer', className)}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+    >
+      {/* LED Dot with glow */}
+      <div className="relative">
+        {/* Pulse animation ring - only when warning or blocked */}
+        {(isBlocked || isWarning) && (
+          <span
+            className={cn(
+              'absolute inset-0 rounded-full animate-ping opacity-75',
+              config.pulseColor,
+              pulseSizeClasses
+            )}
+          />
+        )}
+        {/* Core dot */}
+        <span
+          className={cn(
+            'relative block rounded-full transition-shadow duration-300',
+            config.dotColor,
+            config.glowColor,
+            sizeClasses
+          )}
+        />
+      </div>
+
+      {/* Optional label - shows keyword */}
+      {showLabel && (
+        <span
+          className={cn(
+            'text-[10px] font-medium tracking-wide uppercase opacity-60 transition-opacity',
+            isHovered && 'opacity-100'
+          )}
+        >
+          {config.label}
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{DotElement}</TooltipTrigger>
+        <TooltipContent side="top" className="max-w-[200px]">
+          <p className="text-xs">{config.description}</p>
+          {patterns.length > 0 && (
+            <p className="text-xs text-muted-foreground mt-1">
+              {patterns.length} pattern{patterns.length > 1 ? 's' : ''} detected
+            </p>
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+/**
+ * Hook to get firewall status for applying glow effects to other elements.
+ * Returns CSS class names for glow effects.
+ */
+export function useFirewallGlow() {
+  const { isBlocked, isWarning, isSafe, loading } = useEmotionalFirewall();
+
+  if (loading) {
+    return {
+      glowClass: '',
+      borderClass: '',
+      status: 'loading' as const,
+    };
+  }
+
+  if (isBlocked) {
+    return {
+      glowClass: 'firewall-glow-blocked',
+      borderClass: 'border-red-500/30',
+      status: 'blocked' as const,
+    };
+  }
+
+  if (isWarning) {
+    return {
+      glowClass: 'firewall-glow-warning',
+      borderClass: 'border-yellow-500/30',
+      status: 'warning' as const,
+    };
+  }
+
+  return {
+    glowClass: 'firewall-glow-safe',
+    borderClass: 'border-green-500/20',
+    status: 'safe' as const,
+  };
+}

--- a/web/src/components/emotional-firewall/index.ts
+++ b/web/src/components/emotional-firewall/index.ts
@@ -1,2 +1,3 @@
 export { EmotionalFirewallBanner, EmotionalFirewallIndicator } from './EmotionalFirewallBanner';
 export { TradeWarningModal, useTradeWarningModal } from './TradeWarningModal';
+export { FirewallStatusDot, useFirewallGlow } from './FirewallStatusDot';


### PR DESCRIPTION
Replace the full-width banner strip on mobile with a more subtle UI:
- Add FirewallStatusDot component with LED-style colored dot indicator
- Add useFirewallGlow hook for applying status-based glow to elements
- Integrate dot near send button on mobile ChatInput
- Apply ambient glow effect to input area reflecting firewall status
- Add CSS for firewall-glow-safe/warning/blocked states with pulse animation
- Keep desktop banner unchanged for users who want full details

The dot uses green/yellow/red with subtle glow and tooltip on tap.
The input area picks up a corresponding ambient glow - "hidden in plain sight".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual firewall status indicators with color-coded glow effects to show safety states
  * Implemented animated pulse effects for warning and blocked firewall statuses
  * Introduced a mobile-friendly firewall status indicator in the chat input area
  * Optimized firewall status display across devices (banner on desktop, compact indicator on mobile)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->