### PR TITLE
fix(mobile): make swipe dots dynamic and fix page order

### DIFF
--- a/web/src/components/layout/DeepStackLayout.tsx
+++ b/web/src/components/layout/DeepStackLayout.tsx
@@ -107,12 +107,13 @@ export function DeepStackLayout({ children }: DeepStackLayoutProps) {
                     <main className="flex-1 flex flex-col h-full overflow-hidden pt-0">
                         <MobileSwipeNavigation
                             initialPage={1}
+                            pageIds={['tools', 'chat', 'news', 'markets']}
                             onPageChange={(index, pageId) => {
                                 // Could track analytics or update state here
                                 console.log(`Navigated to page ${index}: ${pageId}`);
                             }}
                         >
-                            {/* Page 0: Chat History */}
+                            {/* Page 0: Tools (Chat/Tools) - swipe RIGHT from home */}
                             <ChatHistoryPage
                                 onSelectConversation={() => {
                                     // Navigate back to chat after selection
@@ -124,17 +125,17 @@ export function DeepStackLayout({ children }: DeepStackLayoutProps) {
                                 }}
                             />
 
-                            {/* Page 1: Chat (HOME) */}
+                            {/* Page 1: Chat (HOME) - Deepstack front page with AI chat & market watcher */}
                             <ChatPage>
                                 <ErrorBoundary variant="fullscreen">
                                     {children}
                                 </ErrorBoundary>
                             </ChatPage>
 
-                            {/* Page 2: Discover/News */}
+                            {/* Page 2: News - swipe LEFT from home */}
                             <DiscoverPage />
 
-                            {/* Page 3: Prediction Markets */}
+                            {/* Page 3: PM (Prediction Markets) - swipe LEFT from news */}
                             <MarketsPage />
                         </MobileSwipeNavigation>
                     </main>


### PR DESCRIPTION
- Fix dots to use actual page count instead of hardcoded PAGE_IDS
- Reorganize pages: Tools(0) | Home(1) | News(2) | PM(3)
- Start on Home page (index 1) with AI chat & market watcher
- Swipe RIGHT to access Tools/Chat History
- Swipe LEFT to access News, then PM (prediction markets)
- Make pageIds configurable via props for flexibility